### PR TITLE
Add thread name to patterns

### DIFF
--- a/src/main/java/com/noveogroup/android/log/Pattern.java
+++ b/src/main/java/com/noveogroup/android/log/Pattern.java
@@ -178,6 +178,17 @@ public abstract class Pattern {
         }
     }
 
+    public static class ThreadNamePattern extends Pattern {
+        public ThreadNamePattern(int count, int length) {
+            super(count, length);
+        }
+
+        @Override
+        protected String doApply(StackTraceElement caller, String loggerName, Logger.Level level) {
+            return Thread.currentThread().getName();
+        }
+    }
+
     private final int count;
     private final int length;
 
@@ -240,6 +251,8 @@ public abstract class Pattern {
                 java.util.regex.Pattern.compile("%([+-]?\\d+)?(\\.([+-]?\\d+))?C(\\{([+-]?\\d+)?(\\.([+-]?\\d+))?\\})?");
         private final java.util.regex.Pattern SOURCE_PATTERN_SHORT =
                 java.util.regex.Pattern.compile("%([+-]?\\d+)?(\\.([+-]?\\d+))?s");
+        private final java.util.regex.Pattern THREAD_NAME_PATTERN =
+                java.util.regex.Pattern.compile("%thread");
 
         public Pattern compile(String string) {
             if (string == null) {
@@ -321,6 +334,11 @@ public abstract class Pattern {
             if ((matcher = findPattern(DATE_PATTERN)) != null || (matcher = findPattern(DATE_PATTERN_SHORT)) != null) {
                 String dateFormat = matcher.group(2);
                 queue.get(queue.size() - 1).addPattern(new DatePattern(0, 0, dateFormat));
+                position = matcher.end();
+                return;
+            }
+            if((matcher = findPattern(THREAD_NAME_PATTERN)) != null){
+                queue.get(queue.size() - 1).addPattern(new ThreadNamePattern(0,0));
                 position = matcher.end();
                 return;
             }

--- a/src/test/java/com/example/PatternTest.java
+++ b/src/test/java/com/example/PatternTest.java
@@ -24,7 +24,7 @@ public class PatternTest {
     Pattern loggerPattern = new Pattern.LoggerPattern(0, 0, 30, 0);
     Pattern callerPattern = new Pattern.CallerPattern(0, 0, 30, 0);
     Pattern sourcePattern = new Pattern.SourcePattern(0, 0);
-
+    Pattern threadPattern = new Pattern.ThreadNamePattern(0,0);
     Pattern.ConcatenatePattern concatenatePattern = new Pattern.ConcatenatePattern(0, 0, new ArrayList<Pattern>());
     Pattern.ConcatenatePattern concatenatePatternChild = new Pattern.ConcatenatePattern(60, 0, new ArrayList<Pattern>());
 
@@ -49,6 +49,9 @@ public class PatternTest {
         Assert.assertEquals("com.noveo.android",
                 loggerPattern.apply(caller, loggerName, level));
 
+        Assert.assertEquals("main",
+                threadPattern.apply(caller, loggerName, level));
+
 
         concatenatePattern.addPattern(dataPattern);
         concatenatePattern.addPattern(spacePattern);
@@ -57,6 +60,8 @@ public class PatternTest {
 
         concatenatePatternChild.addPattern(loggerPattern);
         concatenatePatternChild.addPattern(spacePattern);
+        concatenatePatternChild.addPattern(threadPattern);
+        concatenatePatternChild.addPattern(spacePattern);
         concatenatePatternChild.addPattern(callerPattern);
         concatenatePatternChild.addPattern(sourcePattern);
 
@@ -64,7 +69,7 @@ public class PatternTest {
         concatenatePattern.addPattern(colonPattern);
         concatenatePattern.addPattern(tabPattern);
 
-        Assert.assertEquals("HH:mm:ss D com.noveo.android com.example.PatternTest#<init>:15(PatternTest.java:15):\n".substring(8),
+        Assert.assertEquals("HH:mm:ss D com.noveo.android main com.example.PatternTest#<init>:15(PatternTest.java:15):\n".substring(8),
                 concatenatePattern.apply(caller, loggerName, level).substring(8));
     }
 
@@ -105,6 +110,8 @@ public class PatternTest {
 
         Assert.assertEquals("(PatternTest.java:15)", compiler.compile("%source").apply(caller, loggerName, level));
         Assert.assertEquals("(PatternTest.java:15)", compiler.compile("%s").apply(caller, loggerName, level));
+
+        Assert.assertEquals("[main]", compiler.compile("[%thread]").apply(caller,loggerName, level));
 
         Assert.assertEquals(
                 "HH:mm:ss DEBUG                      com.noveo.android PatternTest#<init>:15:\n".substring(8),


### PR DESCRIPTION
This implements a `%thread` pattern that outputs current thread name.
